### PR TITLE
Add topic guide pages with threads and card layout

### DIFF
--- a/docs/topic-thread-order.md
+++ b/docs/topic-thread-order.md
@@ -1,0 +1,201 @@
+# Topic page post order and thread logic
+
+This document defines the intended post ordering for topic guide pages before
+any Astro, HTML, or CSS changes are made.
+
+## Ordering logic
+
+- Topic membership stays tag-driven from `TOPIC_LANDING_PAGES`.
+- Production topic pages exclude posts with `draft: true`. Local development may
+  include drafts, matching the current `import.meta.env.DEV || !post.data.draft`
+  behavior.
+- A thread exists only when both the parent post and at least one child post
+  match the topic.
+- A thread renders as one sortable block. Its sort date is the newest date among
+  the parent and all included children.
+- A loose post renders as one sortable block. Its sort date is its own post
+  date.
+- Page order is all blocks sorted newest to oldest.
+- If two blocks share the same sort date, thread blocks come before loose posts,
+  then title is used for stable ordering.
+- Children inside a thread sort oldest to newest to preserve the course or
+  project sequence.
+- A child whose parent is outside the topic remains a loose post, with a note
+  that its parent did not qualify for that topic.
+
+Under this model, it is expected and intentional for a page to have a loose post
+above a thread, a loose post below a thread, or both. Freshness is handled at the
+block level without flattening parent-child relationships.
+
+## Current production-visible order
+
+The order below is generated from current frontmatter with drafts excluded.
+
+### Machine Learning
+
+Topic tags: `machine-learning`
+
+1. Post: `Same parts, different wiring: mechanistic interpretability of moral fine-tuning`
+   - Slug: `2026/llm-morality-mech-interp`
+   - Sort date: `2026-02-26`
+2. Thread: `GPU Hardware and Software`
+   - Parent slug: `2026/gpu-retro`
+   - Sort date: `2026-02-25`
+   - Children:
+     1. `FlashAttention & LLM Inference on GPUs` (`2026/gpu-p6`)
+3. Post: `Notes on Effective ML Research`
+   - Slug: `2025/ml-research-notes`
+   - Sort date: `2025-10-18`
+4. Post: `BlueDot AI Safety Evals Paper Club Notes`
+   - Slug: `2025/ai-safety-evals-paper-club-notes`
+   - Sort date: `2025-09-09`
+5. Post: `Hierarchical Reasoning Models`
+   - Slug: `2025/hierarchical-reasoning-models`
+   - Sort date: `2025-09-03`
+6. Thread: `Machine Learning`
+   - Parent slug: `2025/ml-retro`
+   - Sort date: `2025-08-10`
+   - Children:
+     1. `A Practical Guide to Supervised Learning` (`2025/ml-a1`)
+7. Post: `Reflections on ICML 2025`
+   - Slug: `2025/icml`
+   - Sort date: `2025-07-30`
+8. Post: `Language Diffusion Survey`
+   - Slug: `2025/language-diffusion-survey`
+   - Sort date: `2025-05-28`
+9. Post: `Semantic Search`
+   - Slug: `2023/semantic-search`
+   - Sort date: `2023-08-16`
+10. Post: `Language Models`
+    - Slug: `2023/language-models`
+    - Sort date: `2023-05-21`
+
+### Deep Learning
+
+Topic tags: `deep-learning`, `NLP`, `large-language-models`,
+`generative-models`
+
+1. Post: `Same parts, different wiring: mechanistic interpretability of moral fine-tuning`
+   - Slug: `2026/llm-morality-mech-interp`
+   - Sort date: `2026-02-26`
+2. Post: `FlashAttention & LLM Inference on GPUs`
+   - Slug: `2026/gpu-p6`
+   - Sort date: `2026-02-25`
+   - Note: child of `2026/gpu-retro`; parent is outside this topic.
+3. Post: `Hierarchical Reasoning Models`
+   - Slug: `2025/hierarchical-reasoning-models`
+   - Sort date: `2025-09-03`
+4. Post: `Reflections on ICML 2025`
+   - Slug: `2025/icml`
+   - Sort date: `2025-07-30`
+5. Post: `Language Diffusion Survey`
+   - Slug: `2025/language-diffusion-survey`
+   - Sort date: `2025-05-28`
+6. Post: `Semantic Search`
+   - Slug: `2023/semantic-search`
+   - Sort date: `2023-08-16`
+7. Post: `Language Models`
+   - Slug: `2023/language-models`
+   - Sort date: `2023-05-21`
+8. Post: `Search Engine Fundamentals`
+   - Slug: `2022/search-engine-fundamentals`
+   - Sort date: `2022-11-20`
+
+### GPU & Computer Architecture
+
+Topic tags: `GPU`, `CUDA`, `computer-architecture`
+
+1. Thread: `GPU Hardware and Software`
+   - Parent slug: `2026/gpu-retro`
+   - Sort date: `2026-02-25`
+   - Children:
+     1. `CUDA Fundamentals: Tiled Matrix Multiply & Bitonic Sort` (`2026/gpu-p1p2`)
+     2. `GPU Simulation: Warp Scheduling & Compute/Tensor Cores` (`2026/gpu-p3p4`)
+     3. `Static Analysis: Detecting Branch Divergence in GPU Code` (`2026/gpu-p5`)
+     4. `FlashAttention & LLM Inference on GPUs` (`2026/gpu-p6`)
+2. Post: `The Hack Virtual Machine`
+   - Slug: `2022/nand2tetris-vm-translator`
+   - Sort date: `2022-03-12`
+3. Post: `From Boolean Logic Gates to an Assembler`
+   - Slug: `2021/nand2tetris-part1`
+   - Sort date: `2021-09-26`
+
+### Operating Systems & Distributed Systems
+
+Topic tags: `operating-systems`, `distributed-systems`, `multithreading`,
+`IPC`, `socket-programming`
+
+1. Post: `GPU Hardware and Software`
+   - Slug: `2026/gpu-retro`
+   - Sort date: `2026-02-25`
+2. Post: `Concurrency and Parallelism`
+   - Slug: `2025/parallelism-concurrency`
+   - Sort date: `2025-07-29`
+3. Thread: `Graduate Introduction to Operating Systems`
+   - Parent slug: `2025/gios-retro`
+   - Sort date: `2025-07-22`
+   - Children:
+     1. `Building a Scalable Multithreaded File Server in C` (`2025/gios-pr1`)
+     2. `A Deep Dive into IPC with a Proxy-Cache Project` (`2025/gios-pr3`)
+     3. `Building a Distributed File System: A Study in C++` (`2025/gios-pr4`)
+4. Post: `Exponential Backoff and Jitter`
+   - Slug: `2022/exponential-backoff`
+   - Sort date: `2022-09-28`
+
+### AI Safety & Mechanistic Interpretability
+
+Topic tags: `AI-safety`, `mechanistic-interpretability`
+
+1. Post: `Same parts, different wiring: mechanistic interpretability of moral fine-tuning`
+   - Slug: `2026/llm-morality-mech-interp`
+   - Sort date: `2026-02-26`
+2. Post: `Notes on Effective ML Research`
+   - Slug: `2025/ml-research-notes`
+   - Sort date: `2025-10-18`
+3. Post: `BlueDot AI Safety Evals Paper Club Notes`
+   - Slug: `2025/ai-safety-evals-paper-club-notes`
+   - Sort date: `2025-09-09`
+
+## Dev-only draft notes
+
+These posts have `draft: true`, so they may appear in local development but are
+excluded from the production-visible order above.
+
+### Machine Learning drafts
+
+- `Reinforcement Learning and Decision Making` (`2025/rl-retro`)
+- `High-Dimensional Data Analytics` (`2025/hdda-overview`)
+- `Planning and Learning in Markov Decision Processes` (`2025/ml-a4`), child of
+  `2025/ml-retro`
+- `Unsupervised Learning and Linear Dimensionality Reduction` (`2025/ml-a3`),
+  child of `2025/ml-retro`
+- `Randomized Optimization on Discrete Landscapes and Neural Networks`
+  (`2025/ml-a2`), child of `2025/ml-retro`
+
+### Deep Learning drafts
+
+- `Deep Learning` (`2025/dl-retro`)
+- `Reinforcement Learning and Decision Making` (`2025/rl-retro`)
+- `DL Final Project - Crosscoding Reasoning Upgrades`
+  (`2025/dl-final-project`), child of `2025/dl-retro`
+- `DL A4 - VAEs, GANs, and Diffusion on FashionMNIST` (`2025/dl-a4`), child of
+  `2025/dl-retro`
+- `DL A3 - Sequence Models, Attention, and Translation` (`2025/dl-a3`), child
+  of `2025/dl-retro`
+- `DL A2 - Practical CNNs and Imbalanced Data` (`2025/dl-a2`), child of
+  `2025/dl-retro`
+- `DL A1 - Backprop from Scratch` (`2025/dl-a1`), child of `2025/dl-retro`
+
+### GPU & Computer Architecture drafts
+
+- `High Performance Computer Architecture` (`2025/hpca-retro`)
+
+### Operating Systems & Distributed Systems drafts
+
+- `Advanced Operating Systems` (`2025/aos-retro`)
+
+### AI Safety & Mechanistic Interpretability drafts
+
+- `DL Final Project - Crosscoding Reasoning Upgrades`
+  (`2025/dl-final-project`), child of `2025/dl-retro`
+

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -6,17 +6,28 @@ import "../styles/global.css";
 import { SITE_TITLE } from "../consts";
 import RecentPostsScript from "./RecentPostsScript.astro";
 import { getImage } from "astro:assets";
+import {
+  getSiteStructuredData,
+  normalizeStructuredData,
+  type StructuredDataInput,
+} from "../utils/structuredData";
 
 interface Props {
   title: string;
   description: string;
   image?: string | ImageMetadata;
+  structuredData?: StructuredDataInput;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const defaultImage = "/blog-placeholder-2.jpg";
 
-const { title, description, image = defaultImage } = Astro.props;
+const {
+  title,
+  description,
+  image = defaultImage,
+  structuredData,
+} = Astro.props;
 
 // Helper function to get the proper image URL for Open Graph
 const getImageURL = async (imageInput: string | ImageMetadata | undefined) => {
@@ -52,6 +63,10 @@ const getImageURL = async (imageInput: string | ImageMetadata | undefined) => {
 };
 
 const imageURL = await getImageURL(image);
+const structuredDataItems = [
+  ...getSiteStructuredData(Astro.site),
+  ...normalizeStructuredData(structuredData),
+];
 ---
 
 <!-- Theme script to prevent FOUC -->
@@ -146,3 +161,9 @@ const imageURL = await getImageURL(image);
 <meta property="twitter:title" content={`${title} | ${SITE_TITLE}`} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={imageURL} />
+
+{
+  structuredDataItems.map((item) => (
+    <script type="application/ld+json" set:html={JSON.stringify(item)} />
+  ))
+}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,6 +3,13 @@ import HeaderLink from "./HeaderLink.astro";
 import ThemeToggle from "./ThemeToggle.astro";
 import Omnibar from "./Omnibar.astro";
 import { SITE_TITLE } from "../consts";
+import {
+  getLiveTopicsWithCounts,
+  getTopicPath,
+} from "../config/topicLandingPages";
+import { getIconForTopic } from "../utils/topicIcons";
+
+const topics = await getLiveTopicsWithCounts();
 ---
 
 <header>
@@ -16,7 +23,65 @@ import { SITE_TITLE } from "../consts";
     >
     <div class="internal-links">
       <HeaderLink href="/">Home</HeaderLink>
-      <HeaderLink href="/ideas">Ideas</HeaderLink>
+      <div class="nav-item has-menu">
+        <HeaderLink href="/ideas">Ideas</HeaderLink>
+        {
+          topics.length > 0 && (
+            <Fragment>
+              <button
+                type="button"
+                class="ideas-caret"
+                aria-expanded="false"
+                aria-controls="ideas-menu"
+                aria-label="Browse topic guides"
+              >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </button>
+            <div id="ideas-menu" class="ideas-menu" hidden>
+              <div class="ideas-menu-grid">
+                {topics.map(({ topic, count }) => {
+                  const Icon = getIconForTopic(topic.slug);
+                  return (
+                    <a href={getTopicPath(topic.slug)} class="ideas-menu-item">
+                      <span class="ideas-menu-icon">
+                        <Icon size={18} />
+                      </span>
+                      <span class="ideas-menu-text">
+                        <span class="ideas-menu-title">
+                          {topic.title}
+                          <span class="ideas-menu-count">{count}</span>
+                        </span>
+                        <span class="ideas-menu-blurb">{topic.menuBlurb}</span>
+                      </span>
+                    </a>
+                  );
+                })}
+              </div>
+              <div class="ideas-menu-footer">
+                <a href="/ideas" class="ideas-menu-all">
+                  Browse all ideas →
+                </a>
+                <span class="ideas-menu-caption">
+                  Topic guides · auto-built from tags
+                </span>
+              </div>
+            </div>
+            </Fragment>
+          )
+        }
+      </div>
       <HeaderLink href="/about">About</HeaderLink>
       <div
         class="js-missing"
@@ -125,6 +190,146 @@ import { SITE_TITLE } from "../consts";
   .social-links a {
     display: flex;
   }
+
+  /* Ideas dropdown */
+  .nav-item.has-menu {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .nav-item.has-menu > :global(a) {
+    /* The caret sits flush against the link; trim its right padding. */
+    padding-right: 0.2em;
+  }
+  .ideas-caret {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.3em;
+    margin: 0;
+    border: none;
+    background: transparent;
+    color: rgb(var(--black));
+    cursor: pointer;
+    border-radius: 4px;
+    transition:
+      transform 0.2s ease,
+      background-color 0.2s ease;
+  }
+  .ideas-caret:hover {
+    background-color: rgba(var(--black), 6%);
+  }
+  .ideas-caret[aria-expanded="true"] {
+    transform: rotate(180deg);
+  }
+
+  .ideas-menu {
+    position: fixed;
+    top: var(--ideas-menu-top, 4rem);
+    left: var(--ideas-menu-left, 1rem);
+    z-index: 1100;
+    box-sizing: border-box;
+    width: min(620px, calc(100vw - 2rem));
+    max-height: calc(100vh - var(--ideas-menu-top, 4rem) - 1rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 1rem;
+    background: white;
+    border: 1px solid var(--main-border-color, rgba(var(--black), 10%));
+    border-radius: 12px;
+    box-shadow: 0 12px 32px rgba(var(--black), 12%);
+  }
+  .ideas-menu[hidden] {
+    display: none;
+  }
+  .ideas-menu-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.4rem;
+  }
+  .ideas-menu-item {
+    display: flex;
+    gap: 0.7rem;
+    padding: 0.6rem 0.7rem;
+    border-radius: 8px;
+    border-bottom: none;
+    transition: background-color 0.15s ease;
+  }
+  .ideas-menu-item:hover {
+    background-color: var(--base4, rgba(var(--black), 4%));
+  }
+  .ideas-menu-icon {
+    display: flex;
+    flex-shrink: 0;
+    padding-top: 0.15rem;
+    color: var(--accent);
+  }
+  .ideas-menu-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 0;
+  }
+  .ideas-menu-title {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    font-weight: 700;
+    font-size: 0.95rem;
+    line-height: 1.2;
+    color: rgb(var(--black));
+  }
+  .ideas-menu-count {
+    font-weight: 500;
+    font-size: 0.8rem;
+    color: var(--sol-8, rgb(var(--gray)));
+    opacity: 0.65;
+  }
+  .ideas-menu-blurb {
+    font-size: 0.82rem;
+    line-height: 1.35;
+    color: var(--sol-8, rgb(var(--gray)));
+  }
+  .ideas-menu-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--main-border-color, rgba(var(--black), 10%));
+  }
+  /* Scoped under .ideas-menu-footer so it out-specifies the generic `nav a`
+     rule (Astro's cid attributes bump that selector above a bare class). */
+  .ideas-menu-footer .ideas-menu-all {
+    padding: 0;
+    border-bottom: none;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--accent);
+  }
+  .ideas-menu-footer .ideas-menu-all:hover {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+  .ideas-menu-caption {
+    font-size: 0.75rem;
+    color: var(--sol-8, rgb(var(--gray)));
+    opacity: 0.55;
+  }
+
+  :global([data-effective-theme="dark"]) .ideas-menu {
+    background: #073642;
+    border-color: var(--base01, rgba(255, 255, 255, 12%));
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 35%);
+  }
+  :global([data-effective-theme="dark"]) .ideas-menu-item:hover {
+    background-color: rgba(255, 255, 255, 6%);
+  }
+  :global([data-effective-theme="dark"]) .ideas-caret:hover {
+    background-color: rgba(255, 255, 255, 8%);
+  }
+
   @media (max-width: 720px) {
     .social-links {
       display: none;
@@ -134,6 +339,18 @@ import { SITE_TITLE } from "../consts";
     }
     .internal-links {
       gap: 0.25rem;
+    }
+    .ideas-menu {
+      width: calc(100vw - 2rem);
+      border-radius: 10px;
+    }
+    .ideas-menu-grid {
+      grid-template-columns: 1fr;
+    }
+    .ideas-menu-footer {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.4rem;
     }
   }
 </style>
@@ -172,6 +389,121 @@ import { SITE_TITLE } from "../consts";
     window.addEventListener("scroll", update, { passive: true });
   }
 
-  // Initialize when DOM is loaded
-  document.addEventListener("DOMContentLoaded", initHeadroom);
+  function initIdeasMenu() {
+    const navItem = document.querySelector<HTMLElement>(".nav-item.has-menu");
+    const caret = document.querySelector<HTMLButtonElement>(".ideas-caret");
+    const menu = document.querySelector<HTMLElement>("#ideas-menu");
+    if (!navItem || !caret || !menu) return;
+    if (navItem.dataset.ideasMenuInitialized === "true") return;
+    navItem.dataset.ideasMenuInitialized = "true";
+
+    const canHover = window.matchMedia("(hover: hover) and (pointer: fine)");
+    let hoverTimer: ReturnType<typeof setTimeout> | undefined;
+    const viewportGutter = 16;
+
+    function positionMenu() {
+      const svg = caret!.querySelector("svg");
+      const anchorRect = (svg ?? caret!).getBoundingClientRect();
+      const headerRect = navItem!.closest("header")?.getBoundingClientRect();
+      const menuWidth = menu!.offsetWidth;
+      const desktopAlignmentOffset = window.matchMedia("(min-width: 721px)")
+        .matches
+        ? 200
+        : 0;
+      const maxLeft = window.innerWidth - viewportGutter - menuWidth;
+      const idealLeft =
+        anchorRect.right + desktopAlignmentOffset - menuWidth;
+      const left = Math.max(
+        viewportGutter,
+        Math.min(idealLeft, maxLeft)
+      );
+      const top = Math.max(
+        viewportGutter,
+        (headerRect?.bottom ?? anchorRect.bottom) + 8
+      );
+
+      menu!.style.setProperty("--ideas-menu-left", `${Math.round(left)}px`);
+      menu!.style.setProperty("--ideas-menu-top", `${Math.round(top)}px`);
+    }
+
+    function open() {
+      clearTimeout(hoverTimer);
+      menu!.hidden = false;
+      positionMenu();
+      caret!.setAttribute("aria-expanded", "true");
+    }
+    function close() {
+      menu!.hidden = true;
+      caret!.setAttribute("aria-expanded", "false");
+    }
+    function toggle() {
+      menu!.hidden ? open() : close();
+    }
+
+    caret.addEventListener("click", (event) => {
+      event.preventDefault();
+      if (canHover.matches && event.detail > 0) {
+        open();
+        return;
+      }
+      toggle();
+    });
+
+    // Desktop: open on hover, with a small grace period so the cursor can
+    // travel from the caret into the panel without it closing.
+    navItem.addEventListener("mouseenter", () => {
+      if (canHover.matches) open();
+    });
+    navItem.addEventListener("mouseleave", () => {
+      if (canHover.matches) hoverTimer = setTimeout(close, 150);
+    });
+    menu.addEventListener("mouseenter", () => {
+      if (canHover.matches) clearTimeout(hoverTimer);
+    });
+    menu.addEventListener("mouseleave", () => {
+      if (canHover.matches) hoverTimer = setTimeout(close, 150);
+    });
+
+    // Close when a topic link is chosen (before navigation).
+    menu.addEventListener("click", (event) => {
+      if ((event.target as HTMLElement).closest("a")) close();
+    });
+
+    // Close on Escape, returning focus to the caret.
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && !menu.hidden) {
+        close();
+        caret.focus();
+      }
+    });
+
+    // Close on outside click / focus moving away.
+    document.addEventListener("click", (event) => {
+      if (!menu.hidden && !navItem.contains(event.target as Node)) close();
+    });
+    navItem.addEventListener("focusout", () => {
+      // Defer so the newly focused element is settled before we check it.
+      setTimeout(() => {
+        if (!navItem.contains(document.activeElement)) close();
+      }, 0);
+    });
+
+    window.addEventListener("resize", () => {
+      if (!menu!.hidden) positionMenu();
+    });
+    window.addEventListener(
+      "scroll",
+      () => {
+        if (!menu!.hidden) close();
+      },
+      { passive: true }
+    );
+  }
+
+  // Initialize when DOM is loaded, and re-run after client-side navigation.
+  document.addEventListener("DOMContentLoaded", () => {
+    initHeadroom();
+    initIdeasMenu();
+  });
+  document.addEventListener("astro:page-load", initIdeasMenu);
 </script>

--- a/src/config/topicLandingPages.ts
+++ b/src/config/topicLandingPages.ts
@@ -4,6 +4,8 @@ export type TopicLandingPage = {
   slug: string;
   title: string;
   description: string;
+  /** Short, scannable blurb for the nav dropdown — a sentence or less. */
+  menuBlurb: string;
   tags: string[];
   /** Optional framing paragraphs shown under the lede. Write-once, evergreen. */
   intro?: string[];
@@ -15,6 +17,7 @@ export const TOPIC_LANDING_PAGES: TopicLandingPage[] = [
     title: "Machine Learning",
     description:
       "Machine learning notes, course projects, and research writeups on supervised learning, data analysis, evaluation, and model behavior.",
+    menuBlurb: "Supervised learning, evaluation, and model behavior.",
     tags: ["machine-learning"],
     intro: [
       "Two things, mostly. I took a graduate ML course and wrote up a retrospective that covers the whole thing: supervised learning, reinforcement learning, and the theory behind them. The other posts are notes from papers I've read and topics I keep coming back to.",
@@ -26,6 +29,7 @@ export const TOPIC_LANDING_PAGES: TopicLandingPage[] = [
     title: "Deep Learning",
     description:
       "Deep learning notes and projects covering neural networks, sequence models, language models, generative modeling, and interpretability.",
+    menuBlurb: "Architectures, training, and the messy practice of it.",
     tags: [
       "deep-learning",
       "NLP",
@@ -42,6 +46,7 @@ export const TOPIC_LANDING_PAGES: TopicLandingPage[] = [
     title: "GPU & Computer Architecture",
     description:
       "Notes and projects on GPU programming and computer architecture: CUDA kernels, memory hierarchy, warp scheduling and simulation, and building a CPU from logic gates up.",
+    menuBlurb: "CUDA kernels, memory hierarchies, and what the hardware really does.",
     tags: ["GPU", "CUDA", "computer-architecture"],
     intro: [
       "Low-level work, starting from logic gates. The nand2tetris projects build a working computer up from NAND gates and a VM translator. The GPU course goes the other direction into CUDA: tiled kernels, a warp scheduler simulated cycle by cycle, and reading compiled SASS to find branch divergence.",
@@ -53,6 +58,7 @@ export const TOPIC_LANDING_PAGES: TopicLandingPage[] = [
     title: "Operating Systems & Distributed Systems",
     description:
       "Systems writeups on operating systems, concurrency, IPC, sockets, distributed file systems, and reliable server design.",
+    menuBlurb: "Processes, IPC, and systems that span machines.",
     tags: [
       "operating-systems",
       "distributed-systems",
@@ -66,6 +72,7 @@ export const TOPIC_LANDING_PAGES: TopicLandingPage[] = [
     title: "AI Safety & Mechanistic Interpretability",
     description:
       "Research notes and projects on AI safety, evaluations, goal drift, and mechanistic interpretability of model behavior.",
+    menuBlurb: "Reading model internals and the shape of the alignment problem.",
     tags: ["AI-safety", "mechanistic-interpretability"],
   },
 ];
@@ -94,23 +101,46 @@ export function getTopicForTag(tag: string) {
 export const MIN_TOPIC_POSTS = 3;
 
 /**
- * Topics with enough visible posts to be worth a hub page in the current build.
- * Drafts count in dev and are excluded in production, matching how individual
- * post pages are built — so the hub set, the "Part of" links on posts, and the
- * index rail all stay consistent within a single build.
+ * Each topic with its visible-post count. Drafts count in dev and are excluded
+ * in production, matching how individual post pages are built — so the hub set,
+ * the "Part of" links on posts, the nav menu, and the index all stay consistent
+ * within a single build.
  */
-export async function getLiveTopics(
-  minPosts = MIN_TOPIC_POSTS
-): Promise<TopicLandingPage[]> {
+async function getTopicCounts(): Promise<
+  Array<{ topic: TopicLandingPage; count: number }>
+> {
   const ideas = await getCollection("ideas");
   const visible = ideas.filter(
     (post) => import.meta.env.DEV || !post.data.draft
   );
-  return TOPIC_LANDING_PAGES.filter((topic) => {
+  return TOPIC_LANDING_PAGES.map((topic) => {
     const tagSet = new Set(topic.tags);
     const count = visible.filter((post) =>
       post.data.tags?.some((tag) => tagSet.has(tag))
     ).length;
-    return count >= minPosts;
+    return { topic, count };
   });
+}
+
+/**
+ * Topics with enough visible posts to be worth a hub page in the current build.
+ */
+export async function getLiveTopics(
+  minPosts = MIN_TOPIC_POSTS
+): Promise<TopicLandingPage[]> {
+  const counts = await getTopicCounts();
+  return counts
+    .filter(({ count }) => count >= minPosts)
+    .map(({ topic }) => topic);
+}
+
+/**
+ * Live topics paired with their post counts, for surfaces that show the count
+ * (e.g. the nav "Ideas" dropdown).
+ */
+export async function getLiveTopicsWithCounts(
+  minPosts = MIN_TOPIC_POSTS
+): Promise<Array<{ topic: TopicLandingPage; count: number }>> {
+  const counts = await getTopicCounts();
+  return counts.filter(({ count }) => count >= minPosts);
 }

--- a/src/config/topicLandingPages.ts
+++ b/src/config/topicLandingPages.ts
@@ -1,0 +1,116 @@
+import { getCollection } from "astro:content";
+
+export type TopicLandingPage = {
+  slug: string;
+  title: string;
+  description: string;
+  tags: string[];
+  /** Optional framing paragraphs shown under the lede. Write-once, evergreen. */
+  intro?: string[];
+};
+
+export const TOPIC_LANDING_PAGES: TopicLandingPage[] = [
+  {
+    slug: "machine-learning",
+    title: "Machine Learning",
+    description:
+      "Machine learning notes, course projects, and research writeups on supervised learning, data analysis, evaluation, and model behavior.",
+    tags: ["machine-learning"],
+    intro: [
+      "Two things, mostly. I took a graduate ML course and wrote up a retrospective that covers the whole thing: supervised learning, reinforcement learning, and the theory behind them. The other posts are notes from papers I've read and topics I keep coming back to.",
+      "This is the general-purpose end of what I work on. Deep learning, GPUs, and AI safety have their own pages.",
+    ],
+  },
+  {
+    slug: "deep-learning",
+    title: "Deep Learning",
+    description:
+      "Deep learning notes and projects covering neural networks, sequence models, language models, generative modeling, and interpretability.",
+    tags: [
+      "deep-learning",
+      "NLP",
+      "large-language-models",
+      "generative-models",
+    ],
+    intro: [
+      "Neural networks, mostly the language side of them. There's writing on search and semantic search, how language models work, a survey of text diffusion, and some interpretability work that looks at what a model has actually learned.",
+      "It overlaps a lot with the machine learning page. This is the part that's specifically about deep learning and language models.",
+    ],
+  },
+  {
+    slug: "gpu-computer-architecture",
+    title: "GPU & Computer Architecture",
+    description:
+      "Notes and projects on GPU programming and computer architecture: CUDA kernels, memory hierarchy, warp scheduling and simulation, and building a CPU from logic gates up.",
+    tags: ["GPU", "CUDA", "computer-architecture"],
+    intro: [
+      "Low-level work, starting from logic gates. The nand2tetris projects build a working computer up from NAND gates and a VM translator. The GPU course goes the other direction into CUDA: tiled kernels, a warp scheduler simulated cycle by cycle, and reading compiled SASS to find branch divergence.",
+      "Most of it comes down to the same question: what is the hardware actually doing? The answer usually involves memory hierarchy, scheduling, and divergence.",
+    ],
+  },
+  {
+    slug: "operating-systems-distributed-systems",
+    title: "Operating Systems & Distributed Systems",
+    description:
+      "Systems writeups on operating systems, concurrency, IPC, sockets, distributed file systems, and reliable server design.",
+    tags: [
+      "operating-systems",
+      "distributed-systems",
+      "multithreading",
+      "IPC",
+      "socket-programming",
+    ],
+  },
+  {
+    slug: "ai-safety-mechanistic-interpretability",
+    title: "AI Safety & Mechanistic Interpretability",
+    description:
+      "Research notes and projects on AI safety, evaluations, goal drift, and mechanistic interpretability of model behavior.",
+    tags: ["AI-safety", "mechanistic-interpretability"],
+  },
+];
+
+const topicsByTag = new Map<string, TopicLandingPage>();
+
+for (const topic of TOPIC_LANDING_PAGES) {
+  for (const tag of topic.tags) {
+    topicsByTag.set(tag, topic);
+  }
+}
+
+export function getTopicPath(slug: string) {
+  return `/ideas/topics/${slug}/`;
+}
+
+export function getTopicForTag(tag: string) {
+  return topicsByTag.get(tag);
+}
+
+/**
+ * Minimum number of visible posts a topic needs before its hub page is built.
+ * Below this it's a thin page (bad for SEO and a poor landing experience), so
+ * we skip generating it — and skip linking to it from posts and the index.
+ */
+export const MIN_TOPIC_POSTS = 3;
+
+/**
+ * Topics with enough visible posts to be worth a hub page in the current build.
+ * Drafts count in dev and are excluded in production, matching how individual
+ * post pages are built — so the hub set, the "Part of" links on posts, and the
+ * index rail all stay consistent within a single build.
+ */
+export async function getLiveTopics(
+  minPosts = MIN_TOPIC_POSTS
+): Promise<TopicLandingPage[]> {
+  const ideas = await getCollection("ideas");
+  const visible = ideas.filter(
+    (post) => import.meta.env.DEV || !post.data.draft
+  );
+  return TOPIC_LANDING_PAGES.filter((topic) => {
+    const tagSet = new Set(topic.tags);
+    const count = visible.filter((post) =>
+      post.data.tags?.some((tag) => tagSet.has(tag))
+    ).length;
+    return count >= minPosts;
+  });
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,12 +5,14 @@ import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
+import type { StructuredDataInput } from "../utils/structuredData";
 
 interface Props {
   title?: string;
   description?: string;
   image?: string | ImageMetadata;
   noindex?: boolean;
+  structuredData?: StructuredDataInput;
 }
 
 const {
@@ -18,6 +20,7 @@ const {
   description = SITE_DESCRIPTION,
   image,
   noindex = false,
+  structuredData,
 } = Astro.props;
 ---
 
@@ -25,7 +28,12 @@ const {
 <html lang="en">
   <head>
     <title>{title} | {SITE_TITLE}</title>
-    <BaseHead title={title} description={description} image={image} />
+    <BaseHead
+      title={title}
+      description={description}
+      image={image}
+      structuredData={structuredData}
+    />
     {noindex && <meta name="robots" content="noindex, nofollow" />}
   </head>
   <body>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -9,6 +9,13 @@ import TableOfContents from "../components/TableOfContents.astro";
 import Comments from "../components/Comments.astro";
 import BaseLayout from "./BaseLayout.astro";
 import { PenTool, RotateCcw, Code, Lightbulb, Notebook, Youtube } from "lucide-astro";
+import { getBlogPostingStructuredData } from "../utils/structuredData";
+import {
+  getTopicForTag,
+  getTopicPath,
+  getLiveTopics,
+  type TopicLandingPage,
+} from "../config/topicLandingPages";
 
 type Props = CollectionEntry<"ideas">["data"] & {
   headings?: MarkdownHeading[];
@@ -71,6 +78,23 @@ const capitalize = (s: string) => {
   if (typeof s !== "string" || !s) return s;
   return s.charAt(0).toUpperCase() + s.slice(1);
 };
+
+// Tags are filters: every tag chip refines the /ideas list. (Topic membership
+// is surfaced separately, below, as a "Part of" destination link.)
+const tagHref = (tag: string) => `/ideas?tag=${encodeURIComponent(tag)}`;
+
+// The topic hubs this post belongs to — deduped, and limited to hubs that
+// actually exist in this build. This is the reciprocal half of the cluster:
+// the hub links down to its posts, each post links back up to its hub.
+const liveTopicSlugs = new Set((await getLiveTopics()).map((t) => t.slug));
+const topicsForPost = new Map<string, TopicLandingPage>();
+for (const tag of tags ?? []) {
+  const topic = getTopicForTag(tag);
+  if (topic && liveTopicSlugs.has(topic.slug)) {
+    topicsForPost.set(topic.slug, topic);
+  }
+}
+const postTopics = [...topicsForPost.values()];
 ---
 
 <BaseLayout
@@ -171,6 +195,45 @@ const capitalize = (s: string) => {
     }
     .tag:hover {
       background: rgb(var(--accent-dark));
+    }
+
+    .post-topics {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5em;
+      margin-top: 1.5em;
+      font-size: 0.7em;
+    }
+
+    .post-topics-label {
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 600;
+      color: var(--sol-7);
+    }
+
+    .topic-pill {
+      border: 1px solid var(--main-border-color);
+      border-radius: 6px;
+      padding: 0.3em 0.7em;
+      color: var(--sol-8);
+      text-decoration: none;
+      transition: background-color 0.2s ease;
+    }
+
+    .topic-pill:hover {
+      background: var(--base4);
+      color: var(--sol-10);
+    }
+
+    :global([data-effective-theme="dark"]) .topic-pill {
+      border-color: var(--base01);
+    }
+
+    :global([data-effective-theme="dark"]) .topic-pill:hover {
+      background: var(--base02);
+      color: var(--sol-10);
     }
 
     .hero-image {
@@ -290,6 +353,18 @@ const capitalize = (s: string) => {
         </div>
         <h1>{title}</h1>
         <div class="description">{description}</div>
+        {
+          postTopics.length > 0 && (
+            <div class="post-topics">
+              <span class="post-topics-label">Part of</span>
+              {postTopics.map((topic) => (
+                <a class="topic-pill" href={getTopicPath(topic.slug)}>
+                  {topic.title}
+                </a>
+              ))}
+            </div>
+          )
+        }
         <div class="meta">
           {
             tags && tags.length > 0 && (

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -60,6 +60,18 @@ const imageData = getImageData();
 
 // For Open Graph, pass the processed ImageMetadata if available, otherwise the string path
 const ogImage = image?.path || heroImage;
+const postUrl = new URL(Astro.url.pathname, Astro.site);
+const blogPostingStructuredData = getBlogPostingStructuredData({
+  site: Astro.site,
+  url: postUrl,
+  title,
+  description,
+  image: ogImage,
+  publishedAt: pubDate,
+  modifiedAt: updated || pubDate,
+  tags,
+  section: type,
+});
 
 // Map post types to their corresponding icons
 const getIconForType = (type: string) => {
@@ -101,6 +113,7 @@ const postTopics = [...topicsForPost.values()];
   title={title}
   description={description}
   image={ogImage}
+  structuredData={blogPostingStructuredData}
 >
   <style>
     main {

--- a/src/pages/ideas/index.astro
+++ b/src/pages/ideas/index.astro
@@ -6,6 +6,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
 import FormattedDate from "../../components/FormattedDate.astro";
 import readingTime from "reading-time";
 import { TAG_GROUPS } from "../../config/tagGroups";
+import { getTopicPath, getLiveTopics } from "../../config/topicLandingPages";
 import { getIconForType, capitalize } from "../../utils/postIcons";
 
 const posts = (await getCollection("ideas"))
@@ -40,6 +41,10 @@ function buildGroupedTags(tags: string[], groups: Record<string, string[]>) {
 }
 
 const groupedTags = buildGroupedTags(allTags, TAG_GROUPS);
+
+// Only show hubs that were actually built (cleared the post-count threshold),
+// so the rail never links to a topic page that doesn't exist.
+const liveTopics = await getLiveTopics();
 
 const allTypes = [
   ...new Set(posts.map((post) => post.data.type).filter(Boolean)),
@@ -241,6 +246,43 @@ const hierarchicalPosts = allPostsData
     #all-tags.active {
       background-color: var(--accent);
       color: var(--black);
+    }
+    .topic-guides {
+      margin: 0 0 1.4rem;
+    }
+    .topic-guides-label {
+      color: var(--sol-8);
+      display: block;
+      font-size: 0.65rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      margin: 0 0 0.5rem;
+      opacity: 0.45;
+      text-transform: uppercase;
+    }
+    .topic-guide-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+    }
+    .topic-guide-links a {
+      border: 1px solid var(--main-border-color);
+      border-radius: 6px;
+      color: var(--sol-8);
+      font-size: 0.85rem;
+      padding: 0.3rem 0.65rem;
+      text-decoration: none;
+    }
+    .topic-guide-links a:hover {
+      background-color: var(--base4);
+      color: var(--sol-10);
+    }
+    :global([data-effective-theme="dark"]) .topic-guide-links a {
+      border-color: var(--base01);
+    }
+    :global([data-effective-theme="dark"]) .topic-guide-links a:hover {
+      background-color: var(--base02);
+      color: var(--sol-10);
     }
     .post-grid {
       display: flex;
@@ -623,6 +665,18 @@ const hierarchicalPosts = allPostsData
       </div>
 
       <div class="filters" data-pagefind-ignore>
+        {
+          liveTopics.length > 0 && (
+            <div class="topic-guides">
+              <span class="topic-guides-label">Topic Guides</span>
+              <div class="topic-guide-links">
+                {liveTopics.map((topic) => (
+                  <a href={getTopicPath(topic.slug)}>{topic.title}</a>
+                ))}
+              </div>
+            </div>
+          )
+        }
         <ul class="tag-list">
           {
             groupedTags.map(({ group, tags }) => (

--- a/src/pages/ideas/index.astro
+++ b/src/pages/ideas/index.astro
@@ -6,7 +6,6 @@ import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
 import FormattedDate from "../../components/FormattedDate.astro";
 import readingTime from "reading-time";
 import { TAG_GROUPS } from "../../config/tagGroups";
-import { getTopicPath, getLiveTopics } from "../../config/topicLandingPages";
 import { getIconForType, capitalize } from "../../utils/postIcons";
 
 const posts = (await getCollection("ideas"))
@@ -41,10 +40,6 @@ function buildGroupedTags(tags: string[], groups: Record<string, string[]>) {
 }
 
 const groupedTags = buildGroupedTags(allTags, TAG_GROUPS);
-
-// Only show hubs that were actually built (cleared the post-count threshold),
-// so the rail never links to a topic page that doesn't exist.
-const liveTopics = await getLiveTopics();
 
 const allTypes = [
   ...new Set(posts.map((post) => post.data.type).filter(Boolean)),
@@ -246,43 +241,6 @@ const hierarchicalPosts = allPostsData
     #all-tags.active {
       background-color: var(--accent);
       color: var(--black);
-    }
-    .topic-guides {
-      margin: 0 0 1.4rem;
-    }
-    .topic-guides-label {
-      color: var(--sol-8);
-      display: block;
-      font-size: 0.65rem;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      margin: 0 0 0.5rem;
-      opacity: 0.45;
-      text-transform: uppercase;
-    }
-    .topic-guide-links {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.45rem;
-    }
-    .topic-guide-links a {
-      border: 1px solid var(--main-border-color);
-      border-radius: 6px;
-      color: var(--sol-8);
-      font-size: 0.85rem;
-      padding: 0.3rem 0.65rem;
-      text-decoration: none;
-    }
-    .topic-guide-links a:hover {
-      background-color: var(--base4);
-      color: var(--sol-10);
-    }
-    :global([data-effective-theme="dark"]) .topic-guide-links a {
-      border-color: var(--base01);
-    }
-    :global([data-effective-theme="dark"]) .topic-guide-links a:hover {
-      background-color: var(--base02);
-      color: var(--sol-10);
     }
     .post-grid {
       display: flex;
@@ -665,18 +623,6 @@ const hierarchicalPosts = allPostsData
       </div>
 
       <div class="filters" data-pagefind-ignore>
-        {
-          liveTopics.length > 0 && (
-            <div class="topic-guides">
-              <span class="topic-guides-label">Topic Guides</span>
-              <div class="topic-guide-links">
-                {liveTopics.map((topic) => (
-                  <a href={getTopicPath(topic.slug)}>{topic.title}</a>
-                ))}
-              </div>
-            </div>
-          )
-        }
         <ul class="tag-list">
           {
             groupedTags.map(({ group, tags }) => (

--- a/src/pages/ideas/topics/[topic].astro
+++ b/src/pages/ideas/topics/[topic].astro
@@ -1,0 +1,279 @@
+---
+import { getCollection } from "astro:content";
+import readingTime from "reading-time";
+
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import PostCard from "../../../components/PostCard.astro";
+import {
+  getTopicPath,
+  getLiveTopics,
+  type TopicLandingPage,
+} from "../../../config/topicLandingPages";
+import { getCollectionPageStructuredData } from "../../../utils/structuredData";
+
+export async function getStaticPaths() {
+  // Only build hubs that clear the post-count threshold, so we never ship a
+  // thin landing page. Membership is fully tag-driven — nothing is hand-listed.
+  const topics = await getLiveTopics();
+  return topics.map((topic) => ({
+    params: { topic: topic.slug },
+    props: { topic },
+  }));
+}
+
+type Props = {
+  topic: TopicLandingPage;
+};
+
+const { topic } = Astro.props;
+const topicTags = new Set(topic.tags);
+
+const posts = (await getCollection("ideas"))
+  .filter((post) => import.meta.env.DEV || !post.data.draft)
+  .filter((post) => post.data.tags?.some((tag) => topicTags.has(tag)))
+  .sort((a, b) => {
+    const aDate = a.data.pubDate || a.data.date;
+    const bDate = b.data.pubDate || b.data.date;
+    return new Date(bDate || 0).valueOf() - new Date(aDate || 0).valueOf();
+  });
+
+const postCards = posts.map((post) => {
+  const slug = post.id.replace(/(\/index)?\.(md|mdx)$/, "");
+  const stats = readingTime(post.body || "");
+  return {
+    id: post.id,
+    slug,
+    title: post.data.title,
+    description: post.data.description,
+    date: post.data.pubDate || post.data.date,
+    type: post.data.type,
+    status: post.data.status,
+    tags: post.data.tags || [],
+    image: post.data.image,
+    draft: post.data.draft,
+    readingTimeText: stats.text,
+  };
+});
+
+const pageUrl = new URL(getTopicPath(topic.slug), Astro.site);
+const structuredData = getCollectionPageStructuredData({
+  site: Astro.site,
+  url: pageUrl,
+  name: `${topic.title} | Tyler Crosse`,
+  description: topic.description,
+  items: postCards.map((post) => ({
+    name: post.title,
+    url: new URL(`/ideas/${post.slug}/`, Astro.site),
+  })),
+});
+---
+
+<BaseLayout
+  title={topic.title}
+  description={topic.description}
+  structuredData={structuredData}
+>
+  <section class="topic-page">
+    <header class="topic-header slide-in-block">
+      <a href="/ideas/" class="back-link">Ideas</a>
+      <!-- <p class="eyebrow">Topic Guide</p> -->
+      <h1>{topic.title}</h1>
+      <p class="lede">{topic.description}</p>
+      {
+        topic.intro && topic.intro.length > 0 && (
+          <div class="intro">
+            {topic.intro.map((para) => (
+              <p>{para}</p>
+            ))}
+          </div>
+        )
+      }
+      <div class="topic-tags" aria-label={`${topic.title} source tags`}>
+        {
+          topic.tags.map((tag) => (
+            <a href={`/ideas?tag=${encodeURIComponent(tag)}`}>{tag}</a>
+          ))
+        }
+      </div>
+    </header>
+
+    <section
+      class="topic-posts slide-in-block"
+      aria-labelledby="topic-posts-title"
+    >
+      <!-- <div class="section-heading">
+        <h2 id="topic-posts-title">Writing</h2>
+        <span>
+          {postCards.length} {postCards.length === 1 ? "post" : "posts"}
+        </span>
+      </div> -->
+      <div class="post-grid">
+        {postCards.map((post) => <PostCard post={post} variant="compact" />)}
+      </div>
+    </section>
+  </section>
+</BaseLayout>
+
+<style>
+  :global(main) {
+    padding: 2rem 1.5rem 4rem;
+  }
+
+  .topic-page {
+    width: min(100%, 1120px);
+    margin: 0 auto;
+  }
+
+  .topic-header {
+    padding: 1rem 0 0;
+    /* border-bottom: 1px solid var(--sol-7); */
+  }
+
+  .back-link {
+    display: inline-flex;
+    align-items: center;
+    margin-bottom: 1.25rem;
+    color: var(--sol-1);
+    font-size: 0.9rem;
+    text-decoration: none;
+  }
+
+  .back-link::before {
+    content: "←";
+    margin-right: 0.4em;
+  }
+
+  .back-link:hover {
+    color: var(--sol-9);
+  }
+
+  .eyebrow {
+    margin: 0 0 0.4rem;
+    color: var(--sol-1);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  h1 {
+    margin: 0 0 0.85rem;
+    font-size: clamp(2.6rem, 7vw, 4.8rem);
+    line-height: 0.98;
+  }
+
+  .lede {
+    max-width: 70ch;
+    margin: 0;
+    color: var(--sol-1);
+    font-size: 1.05rem;
+    line-height: 1.65;
+  }
+
+  .intro {
+    max-width: 70ch;
+    margin-top: 1.1rem;
+  }
+
+  .intro p {
+    margin: 0 0 0.85rem;
+    color: var(--sol-1);
+    font-size: 1rem;
+    line-height: 1.7;
+  }
+
+  .intro p:last-child {
+    margin-bottom: 0;
+  }
+
+  .topic-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    margin-top: 1.25rem;
+    font-size: 0.85rem;
+  }
+
+  /* Match the tag chips on individual posts (.tag in BlogPost.astro). */
+  .topic-tags a {
+    background: rgb(var(--accent));
+    color: var(--blue);
+    padding-right: 0.5em;
+    border-radius: 0.25em;
+    text-decoration: none;
+    transition: background-color 0.2s ease;
+    text-transform: capitalize;
+  }
+
+  .topic-tags a:hover {
+    background: rgb(var(--accent-dark));
+  }
+
+  .topic-posts {
+    padding-top: 2rem;
+  }
+
+  .section-heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .section-heading h2 {
+    margin: 0;
+    font-size: 1.4rem;
+  }
+
+  .section-heading span {
+    color: var(--sol-1);
+    font-size: 0.9rem;
+  }
+
+  .post-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .slide-in-block {
+    opacity: 0;
+    filter: blur(10px);
+    transform: scale(0.98);
+    will-change: transform, opacity, filter;
+    animation: slideInBlock 0.4s cubic-bezier(0.43, 0.195, 0.02, 1) forwards;
+  }
+
+  .slide-in-block:nth-child(2) {
+    animation-delay: 0.12s;
+  }
+
+  @keyframes slideInBlock {
+    to {
+      opacity: 1;
+      filter: blur(0);
+      transform: scale(1);
+    }
+  }
+
+  @media (max-width: 900px) {
+    .post-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 640px) {
+    :global(main) {
+      padding: 1.5rem 1rem 3rem;
+    }
+
+    .topic-header {
+      padding-top: 0.25rem;
+    }
+
+    .post-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/pages/ideas/topics/[topic].astro
+++ b/src/pages/ideas/topics/[topic].astro
@@ -1,15 +1,18 @@
 ---
 import { getCollection } from "astro:content";
+import { Image } from "astro:assets";
 import readingTime from "reading-time";
 
 import BaseLayout from "../../../layouts/BaseLayout.astro";
-import PostCard from "../../../components/PostCard.astro";
+import FormattedDate from "../../../components/FormattedDate.astro";
+import GradientThumb from "../../../components/GradientThumb.astro";
 import {
   getTopicPath,
   getLiveTopics,
   type TopicLandingPage,
 } from "../../../config/topicLandingPages";
 import { getCollectionPageStructuredData } from "../../../utils/structuredData";
+import { getIconForType, capitalize } from "../../../utils/postIcons";
 
 export async function getStaticPaths() {
   // Only build hubs that clear the post-count threshold, so we never ship a
@@ -28,16 +31,60 @@ type Props = {
 const { topic } = Astro.props;
 const topicTags = new Set(topic.tags);
 
-const posts = (await getCollection("ideas"))
+type TopicPost = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  date?: Date;
+  updated?: Date;
+  type?: string;
+  status?: string;
+  tags: string[];
+  image?: {
+    path?: any;
+    alt?: string;
+  };
+  draft?: boolean;
+  readingTimeText: string;
+  parent?: string;
+};
+
+type TopicBlock =
+  | {
+      kind: "thread";
+      parent: TopicPost;
+      children: TopicPost[];
+      sortDate?: Date;
+    }
+  | {
+      kind: "post";
+      post: TopicPost;
+      sortDate?: Date;
+      parentOutsideTopic?: TopicPost;
+    };
+
+type ThreadBlock = Extract<TopicBlock, { kind: "thread" }>;
+type PostBlock = Extract<TopicBlock, { kind: "post" }>;
+type RenderBlock =
+  | {
+      kind: "thread";
+      block: ThreadBlock;
+    }
+  | {
+      kind: "posts";
+      blocks: PostBlock[];
+    };
+
+const allPosts = (await getCollection("ideas"))
   .filter((post) => import.meta.env.DEV || !post.data.draft)
-  .filter((post) => post.data.tags?.some((tag) => topicTags.has(tag)))
   .sort((a, b) => {
     const aDate = a.data.pubDate || a.data.date;
     const bDate = b.data.pubDate || b.data.date;
     return new Date(bDate || 0).valueOf() - new Date(aDate || 0).valueOf();
   });
 
-const postCards = posts.map((post) => {
+const allPostCards: TopicPost[] = allPosts.map((post) => {
   const slug = post.id.replace(/(\/index)?\.(md|mdx)$/, "");
   const stats = readingTime(post.body || "");
   return {
@@ -52,8 +99,95 @@ const postCards = posts.map((post) => {
     image: post.data.image,
     draft: post.data.draft,
     readingTimeText: stats.text,
+    parent: post.data.parent,
   };
 });
+
+const postCards = allPostCards.filter((post) =>
+  post.tags.some((tag) => topicTags.has(tag))
+);
+const topicSlugs = new Set(postCards.map((post) => post.slug));
+const postsBySlug = new Map(allPostCards.map((post) => [post.slug, post]));
+
+const dateValue = (date?: Date) => date?.valueOf() ?? 0;
+const blockDateValue = (block: TopicBlock) => dateValue(block.sortDate);
+const latestDate = (posts: TopicPost[]) =>
+  posts.reduce<Date | undefined>((latest, post) => {
+    if (!post.date) return latest;
+    if (!latest || post.date.valueOf() > latest.valueOf()) return post.date;
+    return latest;
+  }, undefined);
+
+const parentSlugs = [
+  ...new Set(postCards.map((post) => post.parent).filter(Boolean)),
+] as string[];
+const consumedSlugs = new Set<string>();
+const topicBlocks: TopicBlock[] = [];
+
+for (const parentSlug of parentSlugs) {
+  const parent = postsBySlug.get(parentSlug);
+  if (!parent || !topicSlugs.has(parent.slug)) continue;
+
+  const children = postCards
+    .filter((post) => post.parent === parent.slug && topicSlugs.has(post.slug))
+    .sort(
+      (a, b) =>
+        dateValue(a.date) - dateValue(b.date) ||
+        a.title.localeCompare(b.title)
+    );
+
+  if (children.length === 0) continue;
+
+  consumedSlugs.add(parent.slug);
+  for (const child of children) consumedSlugs.add(child.slug);
+
+  topicBlocks.push({
+    kind: "thread",
+    parent,
+    children,
+    sortDate: latestDate([parent, ...children]),
+  });
+}
+
+for (const post of postCards) {
+  if (consumedSlugs.has(post.slug)) continue;
+  const parentOutsideTopic =
+    post.parent && !topicSlugs.has(post.parent)
+      ? postsBySlug.get(post.parent)
+      : undefined;
+  topicBlocks.push({
+    kind: "post",
+    post,
+    sortDate: post.date,
+    parentOutsideTopic,
+  });
+}
+
+topicBlocks.sort((a, b) => {
+  const dateDelta = blockDateValue(b) - blockDateValue(a);
+  if (dateDelta !== 0) return dateDelta;
+  if (a.kind !== b.kind) return a.kind === "thread" ? -1 : 1;
+  const aTitle = a.kind === "thread" ? a.parent.title : a.post.title;
+  const bTitle = b.kind === "thread" ? b.parent.title : b.post.title;
+  return aTitle.localeCompare(bTitle);
+});
+
+const threadCount = topicBlocks.filter((block) => block.kind === "thread").length;
+const renderBlocks: RenderBlock[] = [];
+
+for (const block of topicBlocks) {
+  if (block.kind === "thread") {
+    renderBlocks.push({ kind: "thread", block });
+    continue;
+  }
+
+  const previousBlock = renderBlocks[renderBlocks.length - 1];
+  if (previousBlock?.kind === "posts") {
+    previousBlock.blocks.push(block);
+  } else {
+    renderBlocks.push({ kind: "posts", blocks: [block] });
+  }
+}
 
 const pageUrl = new URL(getTopicPath(topic.slug), Astro.site);
 const structuredData = getCollectionPageStructuredData({
@@ -101,14 +235,225 @@ const structuredData = getCollectionPageStructuredData({
       class="topic-posts slide-in-block"
       aria-labelledby="topic-posts-title"
     >
-      <!-- <div class="section-heading">
-        <h2 id="topic-posts-title">Writing</h2>
-        <span>
-          {postCards.length} {postCards.length === 1 ? "post" : "posts"}
-        </span>
-      </div> -->
-      <div class="post-grid">
-        {postCards.map((post) => <PostCard post={post} variant="compact" />)}
+
+      <div class="topic-block-list">
+        {
+          renderBlocks.map((renderBlock) => {
+            if (renderBlock.kind === "thread") {
+              const block = renderBlock.block;
+              const ParentIcon = getIconForType(block.parent.type);
+              return (
+                <article class="topic-block topic-thread">
+                  <div class="block-heading">
+                    <div class="block-kicker">
+                      <span>Thread</span>
+                      {block.parent.type && (
+                        <>
+                          <span aria-hidden="true">·</span>
+                          <span>{capitalize(block.parent.type)}</span>
+                        </>
+                      )}
+                      <span aria-hidden="true">·</span>
+                      <span>
+                        {block.children.length}{" "}
+                        {block.children.length === 1 ? "part" : "parts"}
+                      </span>
+                      {block.sortDate && (
+                        <>
+                          <span aria-hidden="true">·</span>
+                          <span>
+                            Updated <FormattedDate date={block.sortDate} />
+                          </span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+
+                  <a
+                    class="thread-lead"
+                    href={`/ideas/${block.parent.slug}/`}
+                  >
+                    <div class="lead-media">
+                      {block.parent.image?.path ? (
+                        <Image
+                          src={block.parent.image.path}
+                          alt={block.parent.image.alt || ""}
+                          width={900}
+                        />
+                      ) : (
+                        <GradientThumb
+                          seed={block.parent.slug}
+                          aspectRatio="4 / 3"
+                        />
+                      )}
+                    </div>
+                    <div class="lead-body">
+                      <div class="post-meta-line">
+                        {block.parent.draft && (
+                          <span class="draft-indicator">DRAFT</span>
+                        )}
+                        {block.parent.type && (
+                          <span class="meta-chunk type-chunk">
+                            {ParentIcon && <ParentIcon size={14} />}
+                            {capitalize(block.parent.type)}
+                          </span>
+                        )}
+                        {block.parent.status && (
+                          <span class="meta-chunk">
+                            {capitalize(block.parent.status)}
+                          </span>
+                        )}
+                        {block.parent.readingTimeText && (
+                          <span class="meta-chunk">
+                            {block.parent.readingTimeText}
+                          </span>
+                        )}
+                      </div>
+                      <h3>{block.parent.title}</h3>
+                      <p>{block.parent.description}</p>
+                      {block.parent.date && (
+                        <div class="post-date">
+                          <FormattedDate date={block.parent.date} />
+                        </div>
+                      )}
+                    </div>
+                  </a>
+
+                  <div
+                    class="thread-children"
+                    data-count={block.children.length}
+                  >
+                    {block.children.map((child) => {
+                      const ChildIcon = getIconForType(child.type);
+                      return (
+                        <a
+                          class="thread-child-card"
+                          href={`/ideas/${child.slug}/`}
+                        >
+                          <div class="child-media">
+                            {child.image?.path ? (
+                              <Image
+                                src={child.image.path}
+                                alt={child.image.alt || ""}
+                                width={360}
+                              />
+                            ) : (
+                              <GradientThumb
+                                seed={child.slug}
+                                aspectRatio="1 / 1"
+                              />
+                            )}
+                          </div>
+                          <div class="child-body">
+                            <div class="post-meta-line">
+                              {child.draft && (
+                                <span class="draft-indicator">DRAFT</span>
+                              )}
+                              {child.type && (
+                                <span class="meta-chunk type-chunk">
+                                  {ChildIcon && <ChildIcon size={13} />}
+                                  {capitalize(child.type)}
+                                </span>
+                              )}
+                              {child.status && (
+                                <span class="meta-chunk">
+                                  {capitalize(child.status)}
+                                </span>
+                              )}
+                              {child.readingTimeText && (
+                                <span class="meta-chunk">
+                                  {child.readingTimeText}
+                                </span>
+                              )}
+                            </div>
+                            <h4>{child.title}</h4>
+                            <p>{child.description}</p>
+                            {child.date && (
+                              <div class="post-date">
+                                <FormattedDate date={child.date} />
+                              </div>
+                            )}
+                          </div>
+                        </a>
+                      );
+                    })}
+                  </div>
+                </article>
+              );
+            }
+
+            return (
+              <div
+                class="topic-block loose-post-grid"
+                data-count={renderBlock.blocks.length}
+              >
+                {renderBlock.blocks.map((block) => {
+                  const PostIcon = getIconForType(block.post.type);
+                  return (
+                    <article class="loose-post-item">
+                      <a
+                        class="loose-post-card"
+                        href={`/ideas/${block.post.slug}/`}
+                      >
+                        <div class="loose-media">
+                          {block.post.image?.path ? (
+                            <Image
+                              src={block.post.image.path}
+                              alt={block.post.image.alt || ""}
+                              width={520}
+                            />
+                          ) : (
+                            <GradientThumb
+                              seed={block.post.slug}
+                              aspectRatio="4 / 3"
+                            />
+                          )}
+                        </div>
+                        <div class="loose-body">
+                          <div class="post-meta-line">
+                            {block.post.draft && (
+                              <span class="draft-indicator">DRAFT</span>
+                            )}
+                            {block.post.type && (
+                              <span class="meta-chunk type-chunk">
+                                {PostIcon && <PostIcon size={14} />}
+                                {capitalize(block.post.type)}
+                              </span>
+                            )}
+                            {block.post.status && (
+                              <span class="meta-chunk">
+                                {capitalize(block.post.status)}
+                              </span>
+                            )}
+                            {block.post.readingTimeText && (
+                              <span class="meta-chunk">
+                                {block.post.readingTimeText}
+                              </span>
+                            )}
+                          </div>
+                          <h3>{block.post.title}</h3>
+                          <p>{block.post.description}</p>
+                          <div class="loose-footer">
+                            {block.post.date && (
+                              <span class="post-date">
+                                <FormattedDate date={block.post.date} />
+                              </span>
+                            )}
+                            {block.parentOutsideTopic && (
+                              <span class="parent-note">
+                                From {block.parentOutsideTopic.title}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      </a>
+                    </article>
+                  );
+                })}
+              </div>
+            );
+          })
+        }
       </div>
     </section>
   </section>
@@ -120,8 +465,13 @@ const structuredData = getCollectionPageStructuredData({
   }
 
   .topic-page {
-    width: min(100%, 1120px);
+    width: min(100%, 1040px);
     margin: 0 auto;
+    --topic-divider: var(--base4);
+  }
+
+  :global([data-effective-theme="dark"]) .topic-page {
+    --topic-divider: var(--base01);
   }
 
   .topic-header {
@@ -153,7 +503,7 @@ const structuredData = getCollectionPageStructuredData({
     font-family: var(--font-mono);
     font-size: 0.78rem;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0;
   }
 
   h1 {
@@ -218,12 +568,14 @@ const structuredData = getCollectionPageStructuredData({
     align-items: baseline;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 1rem;
+    margin-bottom: 1.1rem;
+    padding-bottom: 0.8rem;
+    border-bottom: 1px solid var(--topic-divider);
   }
 
   .section-heading h2 {
     margin: 0;
-    font-size: 1.4rem;
+    font-size: 1.3rem;
   }
 
   .section-heading span {
@@ -231,10 +583,320 @@ const structuredData = getCollectionPageStructuredData({
     font-size: 0.9rem;
   }
 
-  .post-grid {
+  .topic-block-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2.35rem;
+  }
+
+  .topic-block {
+    min-width: 0;
+  }
+
+  .topic-thread {
+    display: flex;
+    flex-direction: column;
+    gap: 0.95rem;
+  }
+
+  .topic-thread:not(:last-child) {
+    padding-bottom: 1.1rem;
+    border-bottom: 1px solid var(--topic-divider);
+  }
+
+  .block-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    min-width: 0;
+  }
+
+  .block-heading::after {
+    content: "";
+    flex: 1 1 auto;
+    height: 1px;
+    background: var(--topic-divider);
+  }
+
+  .block-kicker {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem;
+    min-width: 0;
+    color: var(--sol-7);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    line-height: 1.3;
+    text-transform: uppercase;
+  }
+
+  .block-kicker span:first-child {
+    color: var(--accent);
+    font-weight: 700;
+  }
+
+  .thread-lead,
+  .loose-post-card,
+  .thread-child-card {
+    color: inherit;
+    text-decoration: none;
+    transition:
+      opacity 0.2s ease,
+      transform 0.2s ease,
+      border-color 0.2s ease,
+      background-color 0.2s ease;
+  }
+
+  .thread-lead:focus-visible,
+  .loose-post-card:focus-visible,
+  .thread-child-card:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 3px;
+  }
+
+  .thread-lead {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1rem;
+    grid-template-columns: minmax(220px, 310px) minmax(0, 1fr);
+    gap: 1.45rem;
+    align-items: center;
+    max-width: 960px;
+    padding: 0.1rem 0 0.2rem;
+  }
+
+  .thread-lead:hover,
+  .loose-post-card:hover,
+  .thread-child-card:hover {
+    opacity: 0.9;
+    transform: translateY(-1px);
+  }
+
+  .lead-media,
+  .loose-media,
+  .child-media {
+    overflow: hidden;
+    background: var(--bg-2);
+  }
+
+  .lead-media {
+    aspect-ratio: 4 / 3;
+    border-radius: 8px;
+  }
+
+  .lead-media :global(img),
+  .lead-media :global(.gradient-thumb),
+  .loose-media :global(img),
+  .loose-media :global(.gradient-thumb),
+  .child-media :global(img),
+  .child-media :global(.gradient-thumb) {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .lead-media :global(img),
+  .loose-media :global(img),
+  .child-media :global(img) {
+    object-fit: cover;
+    object-position: center;
+  }
+
+  .lead-body,
+  .loose-body,
+  .child-body {
+    min-width: 0;
+  }
+
+  .loose-body {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    padding: 1rem;
+  }
+
+  .post-meta-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.28rem 0.95rem;
+    color: var(--sol-7);
+    font-size: 0.76rem;
+    line-height: 1.35;
+    text-transform: capitalize;
+  }
+
+  .meta-chunk {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+  }
+
+  .type-chunk :global(svg) {
+    flex-shrink: 0;
+  }
+
+  .lead-body h3,
+  .loose-body h3,
+  .child-body h4 {
+    margin: 0.45rem 0 0;
+    color: var(--sol-10);
+    font-family: var(--font-heading);
+    font-weight: 700;
+    line-height: 1.16;
+  }
+
+  :global([data-effective-theme="dark"]) .lead-body h3,
+  :global([data-effective-theme="dark"]) .loose-body h3,
+  :global([data-effective-theme="dark"]) .child-body h4 {
+    color: var(--sol-5);
+  }
+
+  .lead-body h3 {
+    font-size: clamp(1.55rem, 2.4vw, 2.05rem);
+  }
+
+  .loose-body h3 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1.25rem;
+  }
+
+  .child-body h4 {
+    font-size: 1rem;
+  }
+
+  .lead-body p,
+  .loose-body p,
+  .child-body p {
+    margin: 0.55rem 0 0;
+    color: var(--sol-8);
+    line-height: 1.55;
+  }
+
+  .lead-body p {
+    max-width: 68ch;
+    font-size: 1rem;
+  }
+
+  .loose-body p {
+    margin: 0 0 1rem 0;
+    font-size: 1rem;
+    flex-grow: 1;
+  }
+
+  .child-body p {
+    font-size: 0.86rem;
+  }
+
+  .post-date,
+  .loose-footer,
+  .parent-note {
+    color: var(--sol-7);
+    font-size: 0.82rem;
+  }
+
+  .post-date {
+    margin-top: 0.65rem;
+  }
+
+  .thread-children {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.9rem;
+  }
+
+  .thread-children[data-count="1"] {
+    grid-template-columns: minmax(0, 580px);
+  }
+
+  .loose-post-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.9rem;
+  }
+
+  .loose-post-grid[data-count="1"] {
+    grid-template-columns: minmax(0, 720px);
+  }
+
+  .loose-post-item {
+    min-width: 0;
+  }
+
+  .thread-child-card,
+  .loose-post-card {
+    border: 1px solid var(--main-border-color);
+    background: var(--base4);
+    border-radius: 8px;
+  }
+
+  :global([data-effective-theme="dark"]) .thread-child-card,
+  :global([data-effective-theme="dark"]) .loose-post-card {
+    border-color: var(--base03);
+    background: var(--base02);
+  }
+
+  .thread-child-card {
+    display: grid;
+    grid-template-columns: 104px minmax(0, 1fr);
+    gap: 0.85rem;
+    min-height: 132px;
+    padding: 0.75rem;
+  }
+
+  .child-media {
+    aspect-ratio: 1 / 1;
+    border-radius: 7px;
+  }
+
+  .loose-post-card {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .loose-media {
+    height: 200px;
+    border-radius: 0;
+  }
+
+  .loose-footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem 1rem;
+    align-items: baseline;
+    margin-top: 0;
+  }
+
+  .loose-footer .post-date {
+    margin-top: 0;
+  }
+
+  .parent-note {
+    color: var(--sol-1);
+  }
+
+  .draft-indicator {
+    color: var(--green);
+    font-family: var(--font-body);
+    font-size: 0.62rem;
+    font-weight: 700;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .slide-in-block {
+      animation: none;
+      filter: none;
+      opacity: 1;
+      transform: none;
+    }
+
+    .thread-lead,
+    .loose-post-card,
+    .thread-child-card {
+      transition: none;
+    }
   }
 
   .slide-in-block {
@@ -258,8 +920,19 @@ const structuredData = getCollectionPageStructuredData({
   }
 
   @media (max-width: 900px) {
-    .post-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+    .thread-lead {
+      grid-template-columns: 1fr;
+    }
+
+    .lead-media {
+      max-width: 560px;
+    }
+
+    .loose-post-grid,
+    .loose-post-grid[data-count="1"],
+    .thread-children,
+    .thread-children[data-count="1"] {
+      grid-template-columns: 1fr;
     }
   }
 
@@ -272,8 +945,31 @@ const structuredData = getCollectionPageStructuredData({
       padding-top: 0.25rem;
     }
 
-    .post-grid {
+    .section-heading,
+    .block-heading {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+
+    .topic-block-list {
+      gap: 2rem;
+    }
+
+    .thread-lead {
+      gap: 1rem;
+    }
+
+    .block-heading::after {
+      width: 100%;
+    }
+
+    .thread-child-card {
       grid-template-columns: 1fr;
+    }
+
+    .child-media {
+      width: 96px;
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,11 +57,11 @@ const notebook = [
 ].slice(0, notebookTargetCount);
 
 const themeItems = [
+  { label: "What makes systems honest?" },
   { label: "How do we align systems?" },
   { label: "How do we spot deception?" },
-  { label: "What makes systems honest?" },
   { label: "Which evals matter?" },
-  { label: "How do humans oversee?" },
+  { label: "How do humans have oversight?" },
 ];
 
 const recentWorkGroups = [

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,0 +1,200 @@
+import type { ImageMetadata } from "astro";
+
+import { SITE_DESCRIPTION, SITE_TITLE } from "../consts";
+
+export type StructuredData = Record<string, unknown>;
+export type StructuredDataInput = StructuredData | StructuredData[];
+
+type SiteReference = URL | string | undefined;
+
+type BlogPostingInput = {
+  site: SiteReference;
+  url: URL | string;
+  title: string;
+  description: string;
+  image?: string | ImageMetadata;
+  publishedAt?: Date;
+  modifiedAt?: Date;
+  tags?: string[];
+  section?: string;
+};
+
+type CollectionPageInput = {
+  site: SiteReference;
+  url: URL | string;
+  name: string;
+  description: string;
+  items: Array<{
+    url: URL | string;
+    name: string;
+  }>;
+};
+
+const fallbackSite = "https://www.tylercrosse.com/";
+const personPath = "#person";
+const websitePath = "#website";
+
+function siteRoot(site: SiteReference) {
+  return new URL("/", site ?? fallbackSite);
+}
+
+function absoluteUrl(pathOrUrl: URL | string, site: SiteReference) {
+  return new URL(pathOrUrl, siteRoot(site)).href;
+}
+
+function reference(site: SiteReference, path: string) {
+  return absoluteUrl(path, site);
+}
+
+function dateValue(date: Date | undefined) {
+  return date instanceof Date && !Number.isNaN(date.valueOf())
+    ? date.toISOString()
+    : undefined;
+}
+
+export function normalizeStructuredData(
+  data: StructuredDataInput | undefined,
+) {
+  if (!data) return [];
+  return Array.isArray(data) ? data : [data];
+}
+
+export function imageUrl(
+  image: string | ImageMetadata | undefined,
+  site: SiteReference,
+  fallbackPath = "/blog-placeholder-2.jpg",
+) {
+  if (!image) return absoluteUrl(fallbackPath, site);
+
+  if (typeof image === "string") {
+    return absoluteUrl(image, site);
+  }
+
+  return absoluteUrl(image.src, site);
+}
+
+export function personId(site: SiteReference) {
+  return reference(site, personPath);
+}
+
+export function websiteId(site: SiteReference) {
+  return reference(site, websitePath);
+}
+
+export function getPersonStructuredData(site: SiteReference): StructuredData {
+  const root = siteRoot(site).href;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "@id": personId(site),
+    name: SITE_TITLE,
+    url: root,
+    image: absoluteUrl("/img/headshot.jpeg", site),
+    description:
+      "Research engineer working on AI safety. MSCS Georgia Tech. Senior software engineer and team lead.",
+    sameAs: [
+      "https://github.com/tylercrosse",
+      "https://linkedin.com/in/tylercrosse",
+      "https://scholar.google.com/citations?user=RfFEQLMAAAAJ&hl=en&oi=ao",
+    ],
+    knowsAbout: [
+      "AI safety",
+      "Machine learning",
+      "Mechanistic interpretability",
+      "Software engineering",
+      "Computer systems",
+      "GPU architecture",
+    ],
+    affiliation: {
+      "@type": "CollegeOrUniversity",
+      name: "Georgia Institute of Technology",
+    },
+  };
+}
+
+export function getWebsiteStructuredData(site: SiteReference): StructuredData {
+  const root = siteRoot(site).href;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": websiteId(site),
+    name: SITE_TITLE,
+    url: root,
+    description: SITE_DESCRIPTION,
+    inLanguage: "en-US",
+    author: { "@id": personId(site) },
+    publisher: { "@id": personId(site) },
+  };
+}
+
+export function getSiteStructuredData(site: SiteReference) {
+  return [getPersonStructuredData(site), getWebsiteStructuredData(site)];
+}
+
+export function getBlogPostingStructuredData({
+  site,
+  url,
+  title,
+  description,
+  image,
+  publishedAt,
+  modifiedAt,
+  tags = [],
+  section,
+}: BlogPostingInput): StructuredData {
+  const datePublished = dateValue(publishedAt);
+  const dateModified = dateValue(modifiedAt) ?? datePublished;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "@id": `${absoluteUrl(url, site)}#blogposting`,
+    headline: title,
+    description,
+    url: absoluteUrl(url, site),
+    mainEntityOfPage: absoluteUrl(url, site),
+    image: imageUrl(image, site),
+    datePublished,
+    dateModified,
+    inLanguage: "en-US",
+    author: { "@id": personId(site) },
+    publisher: { "@id": personId(site) },
+    isPartOf: { "@id": websiteId(site) },
+    keywords: tags.length > 0 ? tags.join(", ") : undefined,
+    articleSection: section,
+  };
+}
+
+export function getCollectionPageStructuredData({
+  site,
+  url,
+  name,
+  description,
+  items,
+}: CollectionPageInput): StructuredData {
+  const pageUrl = absoluteUrl(url, site);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${pageUrl}#collectionpage`,
+    name,
+    description,
+    url: pageUrl,
+    inLanguage: "en-US",
+    author: { "@id": personId(site) },
+    publisher: { "@id": personId(site) },
+    isPartOf: { "@id": websiteId(site) },
+    mainEntity: {
+      "@type": "ItemList",
+      itemListElement: items.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: item.name,
+        url: absoluteUrl(item.url, site),
+      })),
+    },
+  };
+}

--- a/src/utils/topicIcons.ts
+++ b/src/utils/topicIcons.ts
@@ -1,0 +1,15 @@
+import { Circle, Diamond, Hexagon, Square, Triangle } from "lucide-astro";
+
+const ICONS_BY_TOPIC = {
+  "machine-learning": Circle,
+  "deep-learning": Diamond,
+  "gpu-computer-architecture": Hexagon,
+  "operating-systems-distributed-systems": Square,
+  "ai-safety-mechanistic-interpretability": Triangle,
+} as const;
+
+export type TopicSlug = keyof typeof ICONS_BY_TOPIC;
+
+export function getIconForTopic(slug: string) {
+  return ICONS_BY_TOPIC[slug as TopicSlug] ?? Circle;
+}


### PR DESCRIPTION
## What this does

Introduces per-topic landing pages under `/ideas/topics/[topic]` and surfaces them through a new Ideas nav dropdown.

### Topic pages (`/ideas/topics/[topic]`)
- Tag-driven membership from `TOPIC_LANDING_PAGES`; only hubs clearing a post-count threshold get built, and drafts are excluded in production.
- Block-based layout: parent/child posts group into **thread blocks** (lead card + child grid), standalone posts render as **loose cards** sorted by freshness. A child whose parent is outside the topic stays loose with a "From {parent}" note.
- Loose-post cards use the vertical layout from `/ideas` (full-width image on top, padded body, meta pinned to bottom) instead of a horizontal grid.
- Thin dividers after thread blocks; section/kicker divider lines use a `--topic-divider` token (`--base4` light, `--base01` dark). Card borders stay on `--main-border-color` to match `/ideas`.
- `docs/topic-thread-order.md` captures the ordering rules and current production-visible post order per topic.

### Ideas nav dropdown
- Replaces the topic-guides rail on `/ideas` with a hover/click dropdown off the Ideas nav link: topic icon, post count, and a one-line `menuBlurb` per item.
- Panel repositions on resize, closes on outside click / Escape / scroll, and re-inits after client-side nav.

### Supporting changes
- `topicLandingPages.ts`: add `menuBlurb`, `getLiveTopicsWithCounts`, `getTopicForTag`; refactor `getLiveTopics` to share the counting helper.
- `topicIcons.ts`: map topic slugs to `lucide-astro` icons.
- `structuredData.ts`: add Person / Website / BlogPosting / CollectionPage utils, piped through `BaseHead` / `BaseLayout` / `BlogPost` as `ld+json`.
- `BlogPost.astro`: "Part of" topic pills linking back to the relevant topic hub.

### Verification
`astro build` passes (44 pages built, all 5 topic pages generated).